### PR TITLE
Remove sub nav on Tutoring page

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,14 +106,6 @@
 
 			<!-- Tutoring -->
 			<article id="tutoring" class="panel">
-				<nav id="tutor-nav" style="display:flex; justify-content: space-evenly; margin-bottom: 2em;">
-					<a href="#offerings-sect">Offerings</a>
-					<a href="#refund-sect">Refund Policy</a>
-					<a href="#availability-sect">Availability</a>
-					<a href="#qualifications-sect">Qualifications</a>
-					<a href="#contact-sect">Contact</a>
-					<a href="#subscribe-sect">Subscribe</a>
-				</nav>
 				<header>
 					<h2>Tutoring</h2>
 				</header>

--- a/index.html
+++ b/index.html
@@ -112,7 +112,6 @@
 				<section>
 					<div class="info-section">
 						<h3 id="offerings-sect">Offerings</h3>
-						<br>
 						<div class="offering">
 							<div class="details">
 								<b>Small Group Python Programming Series</b>


### PR DESCRIPTION
Removed sub nav on tutoring page becuase it was causing issues on page refresh. The hash was unknown to the main nav, so it was redirecting to the home page instead of the tutoring page.